### PR TITLE
Fix language order

### DIFF
--- a/Resources/Private/Partials/Actions/Translate.html
+++ b/Resources/Private/Partials/Actions/Translate.html
@@ -1,6 +1,6 @@
 <f:for each="{item.possible_translations}" key="translationUid" as="link">
 	<f:for each="{languages}" as="language">
-		<f:if condition="{language.uid} > 0 && {language.uid} = {translationUid}">
+		<f:if condition="{language.uid} > 0 && {language.uid} == {translationUid}">
 			<a href="{link}" class="btn btn-default translate" title="{f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.translate')}" data-bs-toggle="tooltip">
 				<core:icon identifier="{language.flagIcon}" size="small" />
 			</a>


### PR DESCRIPTION
* fix language selection: available languages must be set before setting the request language
* change order of queryBuilder constraints: `addSelectLiteral()` becomes unset by `addSelect`.
* minor v12 related issues