### PR TITLE
fix: always add pid to post request

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -1166,10 +1166,7 @@ abstract class AbstractBackendController extends ActionController implements Bac
 
         $url = $this->backendUriBuilder->buildUriFromRoutePath($this->request->getAttribute('module')->getPath());
 
-        $downloadArguments = $this->request->getQueryParams();
-
         $this->moduleTemplate->assignMultiple([
-            'downloadArguments' => $downloadArguments,
             'formats' => array_keys(self::DOWNLOAD_FORMATS),
             'formatOptions' => self::DOWNLOAD_FORMATS,
         ]);

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -26,6 +26,8 @@
 
             <f:form>
 
+                <f:form.hidden name="id" value="{currentPid}" />
+
                 <div class="hidden" id="downloadSettingsForm">
                     <f:render partial="DownloadSettings" arguments="{_all}" />
                 </div>

--- a/Resources/Private/Partials/DownloadSettings.html
+++ b/Resources/Private/Partials/DownloadSettings.html
@@ -94,8 +94,4 @@
     </f:for>
 </f:if>
 
-<f:form.hidden name="id" value="{downloadArguments.id}" />
-<f:form.hidden name="searchString" value="{downloadArguments.searchString}" />
-<f:form.hidden name="searchLevels" value="{downloadArguments.searchLevels}" />
-
 </html>


### PR DESCRIPTION
When removing the download button from the module doc, the pid in the download settings partial overrides the pid with an empty value. This PR removes the hidden fields and ensures that the pid is transferred at every post request.