### PR TITLE
fix: tooltips

### DIFF
--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -4,7 +4,7 @@
     data-namespace-typo3-fluid="true">
 
 <f:be.pageRenderer
-    includeRequireJsModules="{0: 'TYPO3/CMS/Backend/Tooltip'}"
+    includeJavaScriptModules="{0: '@xima/recordlist/contrib/tooltip.js'}"
     includeCssFiles="{0: 'EXT:xima_typo3_recordlist/Resources/Public/Css/recordlist.css'}" />
 
 <f:render section="Before" arguments="{_all}" optional="true" />

--- a/Resources/Public/JavaScript/contrib/tooltip.js
+++ b/Resources/Public/JavaScript/contrib/tooltip.js
@@ -1,0 +1,13 @@
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+import{Tooltip as BootstrapTooltip}from"bootstrap";import DocumentService from"@typo3/core/document-service.js";class Tooltip{constructor(){DocumentService.ready().then((()=>{this.initialize('[data-bs-toggle="tooltip"]')}))}static applyAttributes(t,o){for(const[e,i]of Object.entries(t))o.setAttribute(e,i)}initialize(t,o={}){0===Object.entries(o).length&&(o={container:"body",trigger:"hover",delay:{show:500,hide:100}});const e=document.querySelectorAll(t);for(const t of e)BootstrapTooltip.getOrCreateInstance(t,o)}show(t,o){const e={"data-bs-placement":"auto",title:o};if(t instanceof NodeList)for(const o of t)Tooltip.applyAttributes(e,o),BootstrapTooltip.getInstance(o).show();else if(t instanceof HTMLElement)return Tooltip.applyAttributes(e,t),void BootstrapTooltip.getInstance(t).show()}hide(t){if(t instanceof NodeList)for(const o of t){const t=BootstrapTooltip.getInstance(o);null!==t&&t.hide()}else t instanceof HTMLElement&&BootstrapTooltip.getInstance(t).hide()}}const tooltipObject=new Tooltip;TYPO3.Tooltip=tooltipObject;export default tooltipObject;


### PR DESCRIPTION
This PR loads `tooltip.js` with `includeJavaScriptModules` + includes the JavaScript source as contrib (will be removed in v13)