### PR TITLE
feat: replace edit record links with custom view helper

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -152,7 +152,7 @@ abstract class AbstractBackendController extends ActionController implements Bac
         $this->moduleTemplate->assign('storagePids', implode(',', $this->getAccessiblePids()));
         $this->moduleTemplate->assign('isWorkspaceAdmin', $this->isWorkspaceAdmin());
         $this->moduleTemplate->assign('currentPid', $this->getCurrentPid());
-        $this->moduleTemplate->assign('workspaceId', self::WORKSPACE_ID);
+        $this->moduleTemplate->assign('workspaceId', static::WORKSPACE_ID);
         $this->moduleTemplate->assign('languages', $this->getLanguages());
         $this->moduleTemplate->assign('fullRecordCount', $this->getFullRecordCount());
         $this->moduleTemplate->assign('table', $this->getTableName());

--- a/Classes/Middleware/CurrentWorkspaceManipulation.php
+++ b/Classes/Middleware/CurrentWorkspaceManipulation.php
@@ -21,7 +21,7 @@ class CurrentWorkspaceManipulation implements MiddlewareInterface
          */
         $route = $request->getAttribute('route');
         $identifier = $route->getOption('_identifier');
-        if ($identifier !== 'ajax_workspace_dispatch') {
+        if ($identifier !== 'ajax_workspace_dispatch' && $identifier !== 'record_edit') {
             return $handler->handle($request);
         }
 

--- a/Classes/ViewHelpers/Link/EditRecordViewHelper.php
+++ b/Classes/ViewHelpers/Link/EditRecordViewHelper.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xima\XimaTypo3Recordlist\ViewHelpers\Link;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+
+class EditRecordViewHelper extends AbstractTagBasedViewHelper
+{
+    /**
+     * @var string
+     */
+    protected $tagName = 'a';
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerUniversalTagAttributes();
+        $this->registerArgument('uid', 'int', 'uid of record to be edited', true);
+        $this->registerArgument('table', 'string', 'target database table', true);
+        $this->registerArgument('fields', 'string', 'Edit only these fields (comma separated list)');
+        $this->registerArgument('returnUrl', 'string', 'return to this URL after closing the edit dialog', false, '');
+        $this->registerArgument('workspaceId', 'int', 'workspace uid to respect in edit view', false, 0);
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     * @throws RouteNotFoundException
+     */
+    public function render(): string
+    {
+        if ($this->arguments['uid'] < 1) {
+            throw new \InvalidArgumentException('Uid must be a positive integer, ' . $this->arguments['uid'] . ' given.', 1526127158);
+        }
+        /** @var RenderingContext $renderingContext */
+        $renderingContext = $this->renderingContext;
+        $request = $renderingContext->getRequest();
+        if (empty($this->arguments['returnUrl'])
+            && $request instanceof ServerRequestInterface
+        ) {
+            $this->arguments['returnUrl'] = $request->getAttribute('normalizedParams')->getRequestUri();
+        }
+
+        $params = [
+            'edit' => [$this->arguments['table'] => [$this->arguments['uid'] => 'edit']],
+            'returnUrl' => $this->arguments['returnUrl'],
+            'workspaceId' => $this->arguments['workspaceId'],
+        ];
+        if ($this->arguments['fields'] ?? false) {
+            $params['columnsOnly'] = [
+                $this->arguments['table'] => GeneralUtility::trimExplode(',', $this->arguments['fields'], true),
+            ];
+        }
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+        $uri = (string)$uriBuilder->buildUriFromRoute('record_edit', $params);
+        $this->tag->addAttribute('href', $uri);
+        $this->tag->setContent($this->renderChildren());
+        $this->tag->forceClosingTag(true);
+        return $this->tag->render();
+    }
+}

--- a/Resources/Private/Partials/Actions/Duplicate.html
+++ b/Resources/Private/Partials/Actions/Duplicate.html
@@ -1,18 +1,19 @@
 <html
     data-namespace-typo3-fluid="true"
-    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    xmlns:xm="http://typo3.org/ns/Xima/XimaTypo3Recordlist/ViewHelpers"
     xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
     xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
 
 <f:if condition="{item.sys_language_uid} == 0">
-    <be:link.editRecord
+    <xm:link.editRecord
         class="btn btn-default duplicate"
         data="{bs-toggle: 'tooltip'}"
         table="{table}"
         title="{f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.duplicate')}"
-        uid="{item.uid}">
+        uid="{item.uid}"
+        workspaceId="{workspaceId}">
         <core:icon identifier="actions-duplicate" size="small" />
-    </be:link.editRecord>
+    </xm:link.editRecord>
 </f:if>
 
 </html>

--- a/Resources/Private/Partials/Actions/Edit.html
+++ b/Resources/Private/Partials/Actions/Edit.html
@@ -1,13 +1,14 @@
-{namespace be=TYPO3\CMS\Backend\ViewHelpers}
+{namespace xm=Xima\XimaTypo3Recordlist\ViewHelpers}
 
 <f:if condition="{item.editable}">
-    <be:link.editRecord
+    <xm:link.editRecord
         uid="{item.uid}"
         table="{table}"
         returnUrl="{f:be.uri(route: moduleName)}"
+        workspaceId="{workspaceId}"
         class="btn btn-default"
         title="{f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.edit')}"
         data="{bs-toggle: 'tooltip'}">
         <core:icon identifier="actions-open" size="small" />
-    </be:link.editRecord>
+    </xm:link.editRecord>
 </f:if>

--- a/Resources/Private/Partials/Columns/DateTime.html
+++ b/Resources/Private/Partials/Columns/DateTime.html
@@ -1,12 +1,13 @@
-{namespace be=TYPO3\CMS\Backend\ViewHelpers}
+{namespace xm=Xima\XimaTypo3Recordlist\ViewHelpers}
 
 <f:if condition="{item.editable}">
     <f:then>
-        <be:link.editRecord uid="{item.uid}" table="{table}" returnUrl="{f:be.uri(route: moduleName)}">
+        <xm:link.editRecord
+            returnUrl="{f:be.uri(route: moduleName)}" table="{table}" uid="{item.uid}" workspaceId="{workspaceId}">
             <span class="workspace-state-{item.state}">
                 <f:format.date format="d.m.Y">{item.{colConfig.columnName}}</f:format.date>
             </span>
-        </be:link.editRecord>
+        </xm:link.editRecord>
     </f:then>
     <f:else>
         <span class="workspace-state-{item.state}">

--- a/Resources/Private/Partials/Columns/Select.html
+++ b/Resources/Private/Partials/Columns/Select.html
@@ -1,4 +1,4 @@
-{namespace be=TYPO3\CMS\Backend\ViewHelpers}
+{namespace xm=Xima\XimaTypo3Recordlist\ViewHelpers}
 
 <f:variable name="fieldValue">{item.{colConfig.columnName}}</f:variable>
 <f:if condition="{colConfig.filter.items.{fieldValue}.label}">
@@ -7,10 +7,10 @@
 
 <f:if condition="{item.editable}">
     <f:then>
-        <be:link.editRecord
-            uid="{item.uid}" table="{table}" returnUrl="{f:be.uri(route: moduleName)}">
+        <xm:link.editRecord
+            returnUrl="{f:be.uri(route: moduleName)}" table="{table}" uid="{item.uid}" workspaceId="{workspaceId}">
             <span class="workspace-state-{item.state}">{fieldValue}</span>
-        </be:link.editRecord>
+        </xm:link.editRecord>
     </f:then>
     <f:else>
         <span class="workspace-state-{item.state}">{fieldValue}</span>

--- a/Resources/Private/Partials/Columns/SysFile.html
+++ b/Resources/Private/Partials/Columns/SysFile.html
@@ -1,11 +1,12 @@
 {namespace be=TYPO3\CMS\Backend\ViewHelpers}
+{namespace xm=Xima\XimaTypo3Recordlist\ViewHelpers}
 
 <f:if condition="{item.{colConfig.columnName}}">
     <f:if condition="{item.{colConfig.columnName}.properties.type} == '2'">
-        <be:link.editRecord
-            uid="{item.uid}" table="{table}" returnUrl="{f:be.uri(route: moduleName)}">
+        <xm:link.editRecord
+            returnUrl="{f:be.uri(route: moduleName)}" table="{table}" uid="{item.uid}" workspaceId="{workspaceId}">
             <be:thumbnail image="{item.{colConfig.columnName}}" width="50" height="50" />
-        </be:link.editRecord>
+        </xm:link.editRecord>
     </f:if>
     <f:if condition="{item.{colConfig.columnName}.properties.type} != '2'">
         <core:iconForResource resource="{item.{colConfig.columnName}}" />

--- a/Resources/Private/Partials/Columns/SysFileReferences.html
+++ b/Resources/Private/Partials/Columns/SysFileReferences.html
@@ -1,12 +1,13 @@
 {namespace be=TYPO3\CMS\Backend\ViewHelpers}
+{namespace xm=Xima\XimaTypo3Recordlist\ViewHelpers}
 
 <f:if condition="{item.{colConfig.columnName} -> f:count()}">
     <f:for each="{item.{colConfig.columnName}}" as="item">
         <f:if condition="{item.properties.type} == '2'">
-            <be:link.editRecord
-                uid="{item.uid}" table="{table}" returnUrl="{f:be.uri(route: moduleName)}">
+            <xm:link.editRecord
+                returnUrl="{f:be.uri(route: moduleName)}" table="{table}" uid="{item.uid}" workspaceId="{workspaceId}">
                 <be:thumbnail image="{item}" width="50" height="50" />
-            </be:link.editRecord>
+            </xm:link.editRecord>
         </f:if>
         <f:if condition="{item.properties.type} != '2'">
             <core:iconForResource resource="{item.originalFile}" />

--- a/Resources/Private/Partials/Columns/Text.html
+++ b/Resources/Private/Partials/Columns/Text.html
@@ -1,14 +1,14 @@
-{namespace be=TYPO3\CMS\Backend\ViewHelpers}
+{namespace xm=Xima\XimaTypo3Recordlist\ViewHelpers}
 
 <f:if condition="{colConfig.icon}">
     <core:iconForRecord table="{table}" row="{item}" />
 </f:if>
 <f:if condition="{item.editable}">
     <f:then>
-        <be:link.editRecord
-            uid="{item.uid}" table="{table}" returnUrl="{f:be.uri(route: moduleName)}">
+        <xm:link.editRecord
+            returnUrl="{f:be.uri(route: moduleName)}" table="{table}" uid="{item.uid}" workspaceId="{workspaceId}">
             <span class="workspace-state-{item.state}">{item.{colConfig.columnName} -> f:format.stripTags() -> f:format.crop(maxCharacters: 255)}</span>
-        </be:link.editRecord>
+        </xm:link.editRecord>
     </f:then>
     <f:else>
         <span class="workspace-state-{item.state}">{item.{colConfig.columnName} -> f:format.stripTags() -> f:format.crop(maxCharacters: 255)}</span>

--- a/Resources/Private/Partials/Columns/Thumbnail.html
+++ b/Resources/Private/Partials/Columns/Thumbnail.html
@@ -1,8 +1,9 @@
 {namespace be=TYPO3\CMS\Backend\ViewHelpers}
+{namespace xm=Xima\XimaTypo3Recordlist\ViewHelpers}
 
 <f:if condition="{item.sysFile} && {item.sysFile.type} == 2">
-    <be:link.editRecord
-        uid="{item.uid}" table="{table}" returnUrl="{f:be.uri(route: moduleName)}">
+    <xm:link.editRecord
+        returnUrl="{f:be.uri(route: moduleName)}" table="{table}" uid="{item.uid}" workspaceId="{workspaceId}">
         <be:thumbnail image="{item.sysFile}" width="50" height="50" />
-    </be:link.editRecord>
+    </xm:link.editRecord>
 </f:if>


### PR DESCRIPTION
This PR adds workspace support for (inline) relation records when editing a workspace version of a record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced record edit link component that now supports workspace-specific context in the backend.

- **Refactor**
  - Updated internal processing to allow for more flexible override of configuration constants.
  - Refined conditional handling in the middleware to better manage different request scenarios.
  - Updated various backend templates to incorporate the new edit link format with improved parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->