### PR TITLE
fix: adjust value format of date filter fields

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -486,6 +486,9 @@ abstract class AbstractBackendController extends ActionController implements Bac
                     }
                     $field = 'uid';
                 }
+                if (isset($data['dataType']) && $data['dataType'] === 'date') {
+                    $data['value'] = strtotime($data['value']);
+                }
                 match ($data['expr'] ?? '') {
                     'neq' => $this->additionalConstraints[] = $this->queryBuilder->expr()->neq(
                         't1.' . $field,

--- a/Resources/Private/Partials/Filter/DateTime.html
+++ b/Resources/Private/Partials/Filter/DateTime.html
@@ -14,7 +14,7 @@
             class="formengine-field-item t3js-formengine-field-item d-flex w-100" recordfieldid="{fieldName}">
             <div class="input-group">
                 <f:form.textfield
-                    value="{f:if(condition: fieldValue, then: '{f:format.date(format:\'c\', date: fieldValue)}')}"
+                    value="{f:if(condition: fieldValue, then: '{f:format.date(format:\'Y-m-d\', date: fieldValue)}')}"
                     id="{fieldName}"
                     type="date"
                     name="{fieldName}"

--- a/Resources/Private/Partials/Filter/DateTime.html
+++ b/Resources/Private/Partials/Filter/DateTime.html
@@ -13,6 +13,7 @@
         <typo3-formengine-element-datetime
             class="formengine-field-item t3js-formengine-field-item d-flex w-100" recordfieldid="{fieldName}">
             <div class="input-group">
+                <f:form.hidden name="filter[{colConfig.columnName}][dataType]" value="date"  />
                 <f:form.textfield
                     value="{f:if(condition: fieldValue, then: '{f:format.date(format:\'Y-m-d\', date: fieldValue)}')}"
                     id="{fieldName}"


### PR DESCRIPTION
Input fields with type "date" require format "yyyy-mm-dd".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the date format displayed in date input fields to a simplified year-month-day format for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->