### PR TITLE
fix: add condition to hidden field in datetime partial

### DIFF
--- a/Resources/Private/Partials/Filter/DateTime.html
+++ b/Resources/Private/Partials/Filter/DateTime.html
@@ -4,6 +4,7 @@
     <f:variable name="fieldName" value="filter[{colConfig.columnName}][value]"></f:variable>
     <f:variable name="fieldValue" value="{colConfig.filter.value}"></f:variable>
     <f:variable name="label" value="{colConfig.label}"></f:variable>
+    <f:form.hidden name="filter[{colConfig.columnName}][dataType]" value="date" />
 </f:if>
 
 <div class="row">
@@ -13,9 +14,6 @@
         <typo3-formengine-element-datetime
             class="formengine-field-item t3js-formengine-field-item d-flex w-100" recordfieldid="{fieldName}">
             <div class="input-group">
-                <f:if condition="{colConfig}">
-                    <f:form.hidden name="filter[{colConfig.columnName}][dataType]" value="date" />
-                </f:if>
                 <f:form.textfield
                     value="{f:if(condition: fieldValue, then: '{f:format.date(format:\'Y-m-d\', date: fieldValue)}')}"
                     id="{fieldName}"

--- a/Resources/Private/Partials/Filter/DateTime.html
+++ b/Resources/Private/Partials/Filter/DateTime.html
@@ -13,7 +13,9 @@
         <typo3-formengine-element-datetime
             class="formengine-field-item t3js-formengine-field-item d-flex w-100" recordfieldid="{fieldName}">
             <div class="input-group">
-                <f:form.hidden name="filter[{colConfig.columnName}][dataType]" value="date"  />
+                <f:if condition="{colConfig}">
+                    <f:form.hidden name="filter[{colConfig.columnName}][dataType]" value="date" />
+                </f:if>
                 <f:form.textfield
                     value="{f:if(condition: fieldValue, then: '{f:format.date(format:\'Y-m-d\', date: fieldValue)}')}"
                     id="{fieldName}"


### PR DESCRIPTION
If there is no `colConfig` variable the name of the hidden field would be invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved form reliability by ensuring hidden date input fields are only rendered when valid configuration is present, preventing potential issues with incomplete or invalid form submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->