### PR TITLE
Rename deepl package

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -1023,7 +1023,9 @@ abstract class AbstractBackendController extends ActionController implements Bac
                 $record['possible_translations'] ??= [];
                 $record['possible_translations'][$languageUid] = $targetUrl;
 
-                if (ExtensionManagementUtility::isLoaded('wv_deepltranslate') && \WebVision\WvDeepltranslate\Utility\DeeplBackendUtility::isDeeplApiKeySet()) {
+                if (ExtensionManagementUtility::isLoaded('deepltranslate_core') &&
+                    \WebVision\Deepltranslate\Core\Utility\DeeplBackendUtility::isDeeplApiKeySet()
+                ) {
                     $deeplUrl = (string)$this->backendUriBuilder->buildUriFromRoute('tce_db', [
                         'redirect' => (string)$this->backendUriBuilder->buildUriFromRoute('record_edit', [
                             'justLocalized' => $this->getTableName() . ':' . $record['uid'] . ':' . $languageUid,
@@ -1032,12 +1034,7 @@ abstract class AbstractBackendController extends ActionController implements Bac
                         'cmd' => [
                             $this->getTableName() => [
                                 $record['uid'] => [
-                                    'localize' => $languageUid,
-                                ],
-                            ],
-                            'localization' => [
-                                'custom' => [
-                                    'mode' => 'deepl',
+                                    'deepltranslate' => $languageUid,
                                 ],
                             ],
                         ],

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 	},
 	"suggest": {
 		"typo3/cms-workspaces": "For workspace integration",
-		"web-vision/wv_deepltranslate": "For DeepL integration"
+		"web-vision/deepltranslate-core": "For DeepL integration"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
 		"typo3/cms-workspaces": "^12.4"
 	},
 	"suggest": {
-		"typo3/cms-workspaces": "For workspace integration"
+		"typo3/cms-workspaces": "For workspace integration",
+		"web-vision/wv_deepltranslate": "For DeepL integration"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Hey Maik,

the [deepl package got renamed](https://docs.typo3.org/p/web-vision/deepltranslate-core/main/en-us/Administration/Updates/Index.html). I'm not sure how to react to this.

Strictly speaking it would be a breaking change to only support the new namespace,
and therefore both names should be supported in the recordlist for now.

On the other hand, since this package was not a requirement and only a suggestion until now,
it seems to be legit to use the renamed package right away.

What do you think?