### PR TITLE
JS include via fluid

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -129,16 +129,10 @@ abstract class AbstractBackendController extends ActionController implements Bac
             JavaScriptModuleInstruction::create('@xima/recordlist/recordlist-pagination.js')
         );
         $this->pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
-            JavaScriptModuleInstruction::create('@xima/recordlist/recordlist-action-delete.js')
-        );
-        $this->pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
             JavaScriptModuleInstruction::create('@xima/recordlist/recordlist-loading-animations.js')
         );
         $this->pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
             JavaScriptModuleInstruction::create('@xima/recordlist/recordlist-doc-new-record.js')
-        );
-        $this->pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
-            JavaScriptModuleInstruction::create('@xima/recordlist/recordlist-action-duplicate.js')
         );
 
         $this->setLanguages();
@@ -1068,10 +1062,6 @@ abstract class AbstractBackendController extends ActionController implements Bac
         }
 
         $this->moduleTemplate->assign('hiddenField', $hiddenField);
-
-        $this->pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
-            JavaScriptModuleInstruction::create('@xima/recordlist/recordlist-action-hidden-toggle.js')
-        );
     }
 
     protected function addSysFileReferences(): void

--- a/Resources/Private/Partials/Actions/Duplicate.html
+++ b/Resources/Private/Partials/Actions/Duplicate.html
@@ -4,6 +4,8 @@
     xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
     xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
 
+<f:be.pageRenderer includeJavaScriptModules="{0: '@xima/recordlist/recordlist-action-duplicate.js'}" />
+
 <f:if condition="{item.sys_language_uid} == 0">
     <xm:link.editRecord
         class="btn btn-default duplicate"

--- a/Resources/Private/Partials/Actions/HiddenToggle.html
+++ b/Resources/Private/Partials/Actions/HiddenToggle.html
@@ -1,5 +1,7 @@
 {namespace be=TYPO3\CMS\Backend\ViewHelpers}
 
+<f:be.pageRenderer includeJavaScriptModules="{0: '@xima/recordlist/recordlist-action-hidden-toggle.js'}" />
+
 <f:if condition="{item.editable} && {hiddenField}">
     <a
         href="#"

--- a/Resources/Private/Partials/Actions/Revert.html
+++ b/Resources/Private/Partials/Actions/Revert.html
@@ -1,3 +1,5 @@
+<f:be.pageRenderer includeJavaScriptModules="{0: '@xima/recordlist/recordlist-action-delete.js'}" />
+
 <f:variable name="label">LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.delete</f:variable>
 <f:if condition="{item.t3ver_wsid}">
     <f:variable name="label">LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.revert</f:variable>


### PR DESCRIPTION
This PR relocates the inclusion of JavaScript files to the relevant Fluid partials. This ensures that JS is only loaded when the associated actions are actually used.