### PR TITLE
feat: Add workspace states

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -634,9 +634,10 @@ abstract class AbstractBackendController extends ActionController implements Bac
             }
 
             $record['editable'] = true;
-            $vRecord = BackendUtility::getWorkspaceVersionOfRecord($this::WORKSPACE_ID, $this->getTableName(), $record['uid']);
+            $record['state'] = 'published';
 
-            // has version record => replace with versioned record
+            // if record has a version record => replace with versioned record
+            $vRecord = BackendUtility::getWorkspaceVersionOfRecord($this::WORKSPACE_ID, $this->getTableName(), $record['uid']);
             if (is_array($vRecord)) {
                 $record = $vRecord;
                 $record['editable'] = true;
@@ -661,6 +662,7 @@ abstract class AbstractBackendController extends ActionController implements Bac
                     $workspaceStatus['level'] = 'success';
                     $workspaceStatus['text'] = $this->getLanguageService()->sL('LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.label.waiting');
                     $record['editable'] = $this->isWorkspaceAdmin();
+                    $record['state'] = 'pending';
 
                     $referencesToPublish = [];
                     foreach ($GLOBALS['TCA'][$this->getTableName()]['columns'] as $columnName => $column) {


### PR DESCRIPTION
Pass workspace states to allow adaptions from custom extensions, without the need to recalculate all workspace conditions again.

Should/Could be cherry-picked into the v12/v13 branches, I dont know which branch is the leading one here.

(_We need it for TYPO3 version 13 of a client project_)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace record state management to ensure accurate status tracking during publishing workflows. Records now properly display state indicators when transitioning through different workflow stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->