### PR TITLE
feat: Support content block column labels

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -1099,9 +1099,20 @@ abstract class AbstractBackendController extends ActionController implements Bac
                 $filter = [];
             }
 
+            $label = $config['label'] ?? '';
+            if (!str_starts_with($label, 'LLL:')) {
+                foreach ($GLOBALS['TCA'][$tableName]['types'] ?? [] as $type) {
+                    $overrideLabel = $type['columnsOverrides'][$columnName]['label'] ?? '';
+                    if (str_starts_with($overrideLabel, 'LLL:')) {
+                        $label = $overrideLabel;
+                        break;
+                    }
+                }
+            }
+
             $columns[$columnName] = [
                 'columnName' => $columnName,
-                'label' => $config['label'] ?? '',
+                'label' => $label,
                 'partial' => $partial,
                 'active' => false,
                 'filter' => $filter,


### PR DESCRIPTION
Labels for columns coming from content blocks are initialized different then regular TCA labels via a column override. Detect this state to resolve the correct language labels instead of showing the TCA column name only.

Before: Only showing the column/field name, because content blocks pass the LLL label differently

<img width="671" height="145" alt="Bildschirmfoto vom 2026-04-10 09-26-43" src="https://github.com/user-attachments/assets/f792b6b5-114b-43a7-9392-1d457333afd6" />

After: Columns resolve the correct langauge label

<img width="751" height="166" alt="Bildschirmfoto vom 2026-04-10 09-35-59" src="https://github.com/user-attachments/assets/0d61b7e4-19d8-4c35-bd1a-704db8bc27f1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column label resolution in table configurations by prioritizing type-specific label overrides for better localization support and label consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->