### PR TITLE
fix: always register FormEngine inline settings

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -421,16 +421,18 @@ abstract class AbstractBackendController extends ActionController implements Bac
 
     protected function loadWorkspaceScripts(): void
     {
+        $this->pageRenderer->addInlineSetting(
+            'FormEngine',
+            'moduleUrl',
+            (string)$this->backendUriBuilder->buildUriFromRoute('record_edit')
+        );
+        $this->pageRenderer->addInlineSetting('FormEngine', 'formName', 'editform');
+
         if ($this::WORKSPACE_ID) {
             $this->pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
                 JavaScriptModuleInstruction::create('@xima/recordlist/recordlist-workspace-ready-to-publish.js')
             );
             $this->pageRenderer->addInlineLanguageLabelFile('EXT:workspaces/Resources/Private/Language/locallang.xlf');
-            $this->pageRenderer->addInlineSetting(
-                'FormEngine',
-                'moduleUrl',
-                (string)$this->backendUriBuilder->buildUriFromRoute('record_edit')
-            );
             $this->pageRenderer->addInlineSetting(
                 'RecordHistory',
                 'moduleUrl',


### PR DESCRIPTION
Fixes #51.

`recordlist-row-edit-multiple.js` uses `top.TYPO3.settings.FormEngine.moduleUrl` unconditionally and pulls `@typo3/backend/form-engine.js` as a transitive dependency, which reads `TYPO3.settings.FormEngine.formName` at module-evaluation time. 

With the default `WORKSPACE_ID = 0`, both inline settings were never registered → `Uncaught TypeError: Cannot read properties of undefined (reading 'formName')` on every page load.

Move the two `FormEngine` inline settings in `loadWorkspaceScripts()` out of the `if ($this::WORKSPACE_ID)` branch. `Workspaces`, `RecordHistory` and `WebLayout` stay workspace-only.