### PR TITLE
fix: migrate th dropdown to Bootstrap 5 native toggle

### DIFF
--- a/Resources/Private/Partials/Th.html
+++ b/Resources/Private/Partials/Th.html
@@ -5,7 +5,11 @@
         </f:then>
         <f:else>
             <div class="dropdown dropdown-static">
-                <button class="dropdown-toggle dropdown-toggle-link">
+                <button
+                    type="button"
+                    class="dropdown-toggle dropdown-toggle-link"
+                    data-bs-toggle="dropdown"
+                    aria-expanded="false">
                     {colConfig.label}
                     <f:if condition="{order_field}==={colConfig.columnName}">
                         <div class="text-primary">

--- a/Resources/Public/Css/recordlist.css
+++ b/Resources/Public/Css/recordlist.css
@@ -71,18 +71,9 @@ main.recordlist ul.pagination input.form-control {
     background-color: color-mix(in srgb, var(--typo3-badge-danger-bg) 15%, transparent) !important;
 }
 
-.recordlist table .dropdown-static {
-    position: relative;
-}
-
-.recordlist table .dropdown-static .dropdown-menu {
-    top: 24px;
-}
-
 /**
 * Filter
 */
-
 #filterInputs .card-footer {
     border-top: 1px solid var(--typo3-card-border-color);
 }

--- a/Resources/Public/JavaScript/recordlist-order-links.js
+++ b/Resources/Public/JavaScript/recordlist-order-links.js
@@ -4,29 +4,9 @@ export default class RecordlistOrderLinks {
   }
 
   init() {
-    document.querySelectorAll("th button.dropdown-toggle").forEach(button => {
-      button.addEventListener("click", this.onOrderButtonClick.bind(this));
-    });
-
     document.querySelectorAll("th a[data-order-field]").forEach(button => {
       button.addEventListener("click", this.onOrderLinkClick.bind(this));
     });
-  }
-
-  onOrderButtonClick(e) {
-    e.preventDefault();
-
-    const dropdown = e.currentTarget.nextElementSibling;
-    dropdown.classList.add("show");
-
-    // Close the dropdown if clicked outside
-    const closeDropdown = (event) => {
-      if (!dropdown.contains(event.target) && event.target !== e.currentTarget) {
-        dropdown.classList.remove("show");
-        document.removeEventListener("mousedown", closeDropdown);
-      }
-    };
-    document.addEventListener("mousedown", closeDropdown);
   }
 
   onOrderLinkClick(e) {


### PR DESCRIPTION
TYPO3 v14 requires data-bs-toggle="dropdown" on dropdown buttons for
  Bootstrap 5's Dropdown JS to manage lifecycle (open/close, aria state).
  The previous custom JS toggle conflicted with Bootstrap's document-level
  click handler, causing the sort dropdown to close immediately after opening.

  - Add type="button", data-bs-toggle="dropdown", aria-expanded="false" to Th.html button (mirrors TYPO3 core DatabaseRecordList.php v14 pattern)
  - Remove custom onOrderButtonClick handler — Bootstrap handles toggle natively
  - Remove dropdown-static CSS overrides — Popper.js handles positioning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized record list dropdown functionality to use Bootstrap's native dropdown behavior, replacing custom implementation with standard framework features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->