### PR TITLE
fix: ready to publish filter to apply only if all children are ready as well

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -834,8 +834,12 @@ abstract class AbstractBackendController extends ActionController implements Bac
                     // Live parent may still qualify if it has workspace-modified children.
                     if ($this::WORKSPACE_ID > 0 && !is_array($vRecord)) {
                         $childRefs = $this->collectReferencesToPublish($record);
-                        if ($childRefs !== []) {
-                            $record['_referencesToPublish'] = $childRefs;
+                        $readyChildRefs = array_values(array_filter(
+                            $childRefs,
+                            fn (array $ref): bool => $ref['t3ver_stage'] === self::WORKSPACE_STAGE_READY_TO_PUBLISH
+                        ));
+                        if ($readyChildRefs !== []) {
+                            $record['_referencesToPublish'] = $readyChildRefs;
                         } else {
                             $record = null;
                             continue;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of the "ready to publish" filter to ensure only records meeting publication readiness criteria are processed when managing workspace records with missing overlay information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xima-media/xima-typo3-recordlist/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->