### PR TITLE
Replace checkbox filter with select including yes/no items

### DIFF
--- a/.ddev/commands/web/init-typo3
+++ b/.ddev/commands/web/init-typo3
@@ -45,6 +45,11 @@ _progress "Setting up TYPO3 installation"
     "$typo3Binary" setup --no-interaction --force --quiet
 _done
 
+# Remove setup-created backend users to avoid duplicate fixture imports
+_progress "Reset backend users"
+    mysql -e "DELETE FROM be_users" $dbCredentials "$dbName"
+_done
+
 # Import DB fixtures
 for file in "$fixturePath"/*.sql; do
     _progress "Importing DB fixture \"$(basename "$file")\""

--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -1252,7 +1252,11 @@ abstract class AbstractBackendController extends ActionController implements Bac
             if ($config['config']['type'] === 'check') {
                 $partial = 'Boolean';
                 $filter = [
-                    'partial' => 'Checkbox',
+                    'partial' => 'Select',
+                    'items' => [
+                        0 => ['label' => $this->getLanguageService()->sL(self::TRANSLATION_PATH . 'filter.checkbox.yes'), 'value' => 1],
+                        1 => ['label' => $this->getLanguageService()->sL(self::TRANSLATION_PATH . 'filter.checkbox.no'), 'value' => 0],
+                    ],
                 ];
             }
 

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -259,6 +259,14 @@
 				<source />
 				<target>Aktualisieren</target>
 			</trans-unit>
+			<trans-unit id="filter.checkbox.yes">
+				<source />
+				<target>Ja</target>
+			</trans-unit>
+			<trans-unit id="filter.checkbox.no">
+				<source />
+				<target>Nein</target>
+			</trans-unit>
 			<trans-unit id="filter.expr.label" approved="yes">
 				<source />
 				<target>Art</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -195,6 +195,12 @@
 			<trans-unit id="showColumns.refresh">
 				<source>Refresh</source>
 			</trans-unit>
+			<trans-unit id="filter.checkbox.yes">
+				<source>Yes</source>
+			</trans-unit>
+			<trans-unit id="filter.checkbox.no">
+				<source>No</source>
+			</trans-unit>
 			<trans-unit id="filter.expr.label">
 				<source>Type</source>
 			</trans-unit>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boolean filter columns now display as dropdown selections with "Yes"/"No" options instead of checkboxes.

* **Bug Fixes**
  * Backend users are now properly cleaned up during TYPO3 initialization.
  * Progress output correctly displays completion status.

* **Translations**
  * Added German and English translations for filter options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xima-media/xima-typo3-recordlist/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->