### PR TITLE
feat: use select inputs for workspace status filter

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -376,12 +376,14 @@ abstract class AbstractBackendController extends ActionController implements Bac
 
         // demand: offline records (1/3)
         if (isset($body['is_offline']) && !isset($body['reset'])) {
-            $this->addToModuleDataSettings([$this->getTableName() . '.onlyOfflineRecords' => filter_var($body['is_offline'], FILTER_VALIDATE_BOOLEAN)]);
+            $rawValue = $body['is_offline'];
+            $this->addToModuleDataSettings([$this->getTableName() . '.onlyOfflineRecords' => $rawValue !== '' ? (int)$rawValue : null]);
         }
 
         // demand: readyToPublish (2/3)
         if (isset($body['is_ready_to_publish']) && !isset($body['reset'])) {
-            $this->addToModuleDataSettings([$this->getTableName() . '.onlyReadyToPublish' => filter_var($body['is_ready_to_publish'], FILTER_VALIDATE_BOOLEAN)]);
+            $rawValue = $body['is_ready_to_publish'];
+            $this->addToModuleDataSettings([$this->getTableName() . '.onlyReadyToPublish' => $rawValue !== '' ? (int)$rawValue : null]);
         }
 
         // demand: items per page (3/3)
@@ -849,7 +851,8 @@ abstract class AbstractBackendController extends ActionController implements Bac
             $record['_workspaceVersion'] = is_array($vRecord) ? $vRecord : null;
 
             // demand: readyToPublish
-            if ($this->getModuleDataSetting($this->getTableName() . '.onlyReadyToPublish')) {
+            $readyToPublishSetting = $this->getModuleDataSetting($this->getTableName() . '.onlyReadyToPublish');
+            if ($readyToPublishSetting == 1) {
                 $parentIsReady = is_array($vRecord) && $vRecord['t3ver_stage'] === self::WORKSPACE_STAGE_READY_TO_PUBLISH;
                 if (!$parentIsReady) {
                     // Live parent may still qualify if it has workspace-modified children.
@@ -866,10 +869,17 @@ abstract class AbstractBackendController extends ActionController implements Bac
                         continue;
                     }
                 }
+            } elseif ($readyToPublishSetting === -1) {
+                $parentIsReady = is_array($vRecord) && $vRecord['t3ver_stage'] === self::WORKSPACE_STAGE_READY_TO_PUBLISH;
+                if ($parentIsReady) {
+                    $record = null;
+                    continue;
+                }
             }
 
             // demand: offline records
-            if ($this->getModuleDataSetting($this->getTableName() . '.onlyOfflineRecords') && !is_array($vRecord)) {
+            $offlineRecordsSetting = $this->getModuleDataSetting($this->getTableName() . '.onlyOfflineRecords');
+            if ($offlineRecordsSetting == 1 && !is_array($vRecord)) {
                 $hasChildChanges = false;
                 if ($this::WORKSPACE_ID > 0) {
                     $childRefs = $record['_referencesToPublish'] ?? $this->collectReferencesToPublish($record);
@@ -882,6 +892,9 @@ abstract class AbstractBackendController extends ActionController implements Bac
                     $record = null;
                     continue;
                 }
+            } elseif ($offlineRecordsSetting === -1 && is_array($vRecord)) {
+                $record = null;
+                continue;
             }
         }
         unset($record);
@@ -1390,6 +1403,10 @@ abstract class AbstractBackendController extends ActionController implements Bac
                 'active' => false,
                 'filter' => [
                     'partial' => 'Workspace',
+                    'items' => [
+                        0 => ['label' => $this->getLanguageService()->sL(self::TRANSLATION_PATH . 'filter.checkbox.yes'), 'value' => 1],
+                        1 => ['label' => $this->getLanguageService()->sL(self::TRANSLATION_PATH . 'filter.checkbox.no'), 'value' => -1],
+                    ],
                 ],
             ];
         }
@@ -1895,10 +1912,10 @@ abstract class AbstractBackendController extends ActionController implements Bac
         }
 
         // Count workspace filters from module data
-        if ($this->getModuleDataSetting($tableName . '.onlyOfflineRecords')) {
+        if ($this->getModuleDataSetting($tableName . '.onlyOfflineRecords') !== null) {
             $count++;
         }
-        if ($this->getModuleDataSetting($tableName . '.onlyReadyToPublish')) {
+        if ($this->getModuleDataSetting($tableName . '.onlyReadyToPublish') !== null) {
             $count++;
         }
 

--- a/Resources/Private/Partials/Filter/Select.html
+++ b/Resources/Private/Partials/Filter/Select.html
@@ -1,11 +1,10 @@
+<f:variable name="optionValueField" value="value" />
+<f:variable name="optionLabelField" value="label" />
 <f:if condition="{colConfig}">
     <f:variable name="fieldName" value="filter[{colConfig.columnName}][value]" />
     <f:variable name="fieldValue" value="{colConfig.filter.value}" />
     <f:variable name="label" value="{colConfig.label}" />
     <f:variable name="fieldOptions" value="{colConfig.filter.items}" />
-    <f:variable name="optionValueField" value="value" />
-    <f:variable name="optionLabelField" value="label" />
-
 </f:if>
 
 <div class="row">

--- a/Resources/Private/Partials/Filter/Workspace.html
+++ b/Resources/Private/Partials/Filter/Workspace.html
@@ -1,15 +1,12 @@
 <div class="row mb-3">
-    <div class="col-12">
-        <label class="form-label">
-            {f:translate(key: 'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.column.status')}
-        </label>
-    </div>
-    <div class="col-auto">
+    <div class="col-6">
         <f:render
-            partial="Filter/Checkbox" arguments="{fieldName: 'is_offline', fieldValue: '{settings.{table}.onlyOfflineRecords}', label: '{f:translate(key: \'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.label.copy\')}'}" />
+            partial="Filter/Select"
+            arguments="{fieldName: 'is_offline', fieldValue: '{settings.{table}.onlyOfflineRecords}', label: '{f:translate(key: \'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.label.copy\')}', fieldOptions: colConfig.filter.items}" />
     </div>
-    <div class="col-auto">
+    <div class="col-6">
         <f:render
-            partial="Filter/Checkbox" arguments="{fieldName: 'is_ready_to_publish', fieldValue: '{settings.{table}.onlyReadyToPublish}', label: '{f:translate(key: \'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.label.waiting\')}'}" />
+            partial="Filter/Select"
+            arguments="{fieldName: 'is_ready_to_publish', fieldValue: '{settings.{table}.onlyReadyToPublish}', label: '{f:translate(key: \'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.label.waiting\')}', fieldOptions: colConfig.filter.items}" />
     </div>
 </div>

--- a/Resources/Public/Css/recordlist.css
+++ b/Resources/Public/Css/recordlist.css
@@ -120,7 +120,7 @@ main.recordlist ul.pagination input.form-control {
 }
 
 @media (min-width: 1400px) {
-    #filterInputs .col-xxl-6 .row {
+    #filterInputs .col-xxl-6 > .row {
         max-width: 90%;
     }
 }


### PR DESCRIPTION
resolves #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace status filters now use dropdown select controls instead of checkboxes, offering enhanced filtering options for offline records and publication status.
  * Added support for both affirmative and negative filtering states, enabling more precise record management.

* **Style**
  * Refined responsive layout behavior for filter sections on larger displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->