### PR TITLE
feat: add reset-view button

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -224,7 +224,9 @@ abstract class AbstractBackendController extends ActionController implements Bac
         $this->modifyTableConfiguration();
         $this->processTableConfiguration();
 
-        if (isset($this->request->getParsedBody()['is_download']) && $this->request->getParsedBody()['is_download'] === '1') {
+        $parsedBody = $this->request->getParsedBody();
+        $parsedBody = is_array($parsedBody) ? $parsedBody : [];
+        if (($parsedBody['is_download'] ?? null) === '1') {
             return $this->downloadRecords();
         }
 
@@ -417,10 +419,10 @@ abstract class AbstractBackendController extends ActionController implements Bac
             $languages[-1]['uid'] = 'all';
         }
 
-        $activeLanguage = $this->getActiveLanguage();
+        $activeLanguage = (string)$this->getActiveLanguage();
         foreach ($languages as &$language) {
             // needs to be strict type checking as this is not possible in fluid
-            if ((string)$language['uid'] === $activeLanguage) {
+            if ((string)($language['uid'] ?? '') === $activeLanguage) {
                 $language['active'] = true;
             }
         }
@@ -576,8 +578,9 @@ abstract class AbstractBackendController extends ActionController implements Bac
     protected function addSearchConstraint(): void
     {
         $body = $this->request->getParsedBody();
-        if (isset($body['search_field']) && $body['search_field']) {
-            $searchInput = $body['search_field'];
+        $body = is_array($body) ? $body : [];
+        $searchInput = (string)($body['search_field'] ?? '');
+        if ($searchInput !== '') {
             $escapedSearchInput = addcslashes($searchInput, '%_');
             $searchFields = $GLOBALS['TCA'][$this->getTableName()]['ctrl']['searchFields'] ?? $GLOBALS['TCA'][$this->getTableName()]['ctrl']['label'];
             $searchFieldArray = GeneralUtility::trimExplode(',', $searchFields, true);
@@ -607,7 +610,11 @@ abstract class AbstractBackendController extends ActionController implements Bac
     protected function addFilterConstraint(): void
     {
         $body = $this->request->getParsedBody();
+        $body = is_array($body) ? $body : [];
         $bodyFilters = (array)($body['filter'] ?? []);
+        $tableName = $this->getTableName();
+        $tableTca = is_array($GLOBALS['TCA'][$tableName] ?? null) ? $GLOBALS['TCA'][$tableName] : [];
+        $columns = is_array($tableTca['columns'] ?? null) ? $tableTca['columns'] : [];
 
         // Merge default filters — user-submitted values take precedence per field
         $filters = $bodyFilters;
@@ -619,19 +626,23 @@ abstract class AbstractBackendController extends ActionController implements Bac
 
         if (!empty($filters)) {
             foreach ($filters as $field => $data) {
+                if (!is_array($data)) {
+                    continue;
+                }
                 // Validate field name against TCA
-                if ($field !== 'uid' && !isset($GLOBALS['TCA'][$this->getTableName()]['columns'][$field])) {
+                if ($field !== 'uid' && !isset($columns[$field])) {
                     continue;
                 }
                 if (!isset($data['value']) || $data['value'] === '') {
                     continue;
                 }
 
-                $columnType = $GLOBALS['TCA'][$this->getTableName()]['columns'][$field]['config']['type'] ?? '';
+                $fieldConfig = is_array($columns[$field]['config'] ?? null) ? $columns[$field]['config'] : [];
+                $columnType = (string)($fieldConfig['type'] ?? '');
 
                 if (in_array($columnType, ['select', 'category', 'group', 'inline'], true)) {
                     $filterResult = $this->relationResolver->resolveForFilter(
-                        $this->getTableName(),
+                        $tableName,
                         $field,
                         $data['value'],
                         $this::WORKSPACE_ID
@@ -640,8 +651,8 @@ abstract class AbstractBackendController extends ActionController implements Bac
                     continue;
                 }
 
-                if (isset($data['dataType']) && $data['dataType'] === 'date') {
-                    $dbType = $GLOBALS['TCA'][$this->getTableName()]['columns'][$field]['config']['dbType'] ?? '';
+                if (($data['dataType'] ?? null) === 'date') {
+                    $dbType = (string)($fieldConfig['dbType'] ?? '');
                     $date = date('Y-m-d', strtotime($data['value']));
                     if ($dbType === 'date' || $dbType === 'datetime') {
                         $leftExpr = 'DATE(t1.' . $field . ')';

--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -354,11 +354,18 @@ abstract class AbstractBackendController extends ActionController implements Bac
         if ($this->request->getMethod() === 'POST') {
             unset($body['__referrer'], $body['__trustedProperties'], $body['is_download']);
 
+            $isReset = isset($body['reset']) || isset($body['reset_view']);
+            $isResetView = isset($body['reset_view']);
+
             // clear moduleData + current request body in case reset button is used for submit
-            if (isset($body['reset'])) {
+            if ($isReset) {
                 $body = [];
                 $this->request = $this->request->withParsedBody([]);
                 unset($moduleData['settings']['language'], $moduleData['settings'][$tableName . '.isFilterButtonActive'], $moduleData['settings'][$tableName . '.onlyOfflineRecords'], $moduleData['settings'][$tableName . '.onlyReadyToPublish'], $moduleData['settings'][$tableName . '.itemsPerPage']);
+            }
+
+            if ($isResetView) {
+                unset($moduleData['settings'][$tableName . '.activeColumns']);
             }
 
             $moduleData[$tableName . '.search'] = $body;
@@ -1866,6 +1873,36 @@ abstract class AbstractBackendController extends ActionController implements Bac
             ->setAttributes(['data-doc-button' => 'showColumnsButton']);
     }
 
+    protected function addResetViewButtonToViewDropdown(): void
+    {
+        if (!$this->isActionAllowedInCurrentTemplate('resetView')) {
+            return;
+        }
+
+        $this->pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
+            JavaScriptModuleInstruction::create('@xima/recordlist/recordlist-reset-view.js')
+        );
+
+        if ($this->getTypo3Version() === 13) {
+            $this->viewDropdownButtons[] = GeneralUtility::makeInstance(\TYPO3\CMS\Backend\Template\Components\Buttons\DropDown\DropDownItem::class)
+                ->setHref('#')
+                ->setLabel($this->getLanguageService()->sL(self::TRANSLATION_PATH . 'header.button.resetView'))
+                ->setTitle($this->getLanguageService()->sL(self::TRANSLATION_PATH . 'header.button.resetView'))
+                ->setIcon($this->iconFactory->getIcon('actions-undo', IconSize::SMALL))
+                ->setAttributes(['data-doc-button' => 'resetViewButton']);
+            return;
+        }
+
+        $componentFactory = GeneralUtility::makeInstance(\TYPO3\CMS\Backend\Template\Components\ComponentFactory::class);
+        $this->viewDropdownButtons[] = $componentFactory->createDropDownItem()
+            ->setTag('a')
+            ->setHref('#')
+            ->setLabel($this->getLanguageService()->sL(self::TRANSLATION_PATH . 'header.button.resetView'))
+            ->setTitle($this->getLanguageService()->sL(self::TRANSLATION_PATH . 'header.button.resetView'))
+            ->setIcon($this->iconFactory->getIcon('actions-undo', IconSize::SMALL))
+            ->setAttributes(['data-doc-button' => 'resetViewButton']);
+    }
+
     protected function addDownloadButtonToModuleTemplate(): void
     {
         if (!$this->isActionAllowedInCurrentTemplate('download')) {
@@ -2220,6 +2257,9 @@ abstract class AbstractBackendController extends ActionController implements Bac
 
         // show columns
         $this->addShowColumnsButtonToViewDropdown();
+
+        // reset view
+        $this->addResetViewButtonToViewDropdown();
     }
 
     protected function addTemplateSelectionToViewDropdown(): void
@@ -2278,7 +2318,7 @@ abstract class AbstractBackendController extends ActionController implements Bac
             'Default' => [
                 'title' => 'Page List',
                 'icon' => 'actions-list',
-                'actions' => ['templateSelection', 'showColumns', 'download', 'toggleFilters', 'tableSelection', 'pidSelection', 'languageSelection', 'newRecord'],
+                'actions' => ['templateSelection', 'showColumns', 'resetView', 'download', 'toggleFilters', 'tableSelection', 'pidSelection', 'languageSelection', 'newRecord'],
             ],
         ];
     }

--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -351,6 +351,7 @@ abstract class AbstractBackendController extends ActionController implements Bac
     {
         $moduleData = $this->getModuleData();
         $body = $this->request->getParsedBody();
+        $body = is_array($body) ? $body : [];
         $tableName = $this->getTableName();
 
         if ($this->request->getMethod() === 'POST') {

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -227,6 +227,10 @@
 				<source />
 				<target>Spalten anpassen</target>
 			</trans-unit>
+			<trans-unit id="header.button.resetView" approved="yes">
+				<source />
+				<target>Ansicht zurücksetzen</target>
+			</trans-unit>
 			<trans-unit id="showColumns.filter" approved="yes">
 				<source />
 				<target>Filtern nach</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -171,6 +171,9 @@
 			<trans-unit id="header.button.showColumns">
 				<source>Show columns</source>
 			</trans-unit>
+			<trans-unit id="header.button.resetView">
+				<source>Reset view</source>
+			</trans-unit>
 			<trans-unit id="showColumns.filter">
 				<source>Filter by</source>
 			</trans-unit>

--- a/Resources/Public/JavaScript/recordlist-reset-view.js
+++ b/Resources/Public/JavaScript/recordlist-reset-view.js
@@ -1,0 +1,29 @@
+import DocumentService from "@typo3/core/document-service.js";
+
+export default class RecordlistResetView {
+  constructor() {
+    DocumentService.ready().then(() => {
+      this.init();
+    });
+  }
+
+  init() {
+    document.querySelectorAll('*[data-doc-button="resetViewButton"]').forEach(button => {
+      button.addEventListener("click", this.onResetViewClick.bind(this));
+    });
+  }
+
+  onResetViewClick(e) {
+    e.preventDefault();
+    const form = document.querySelector('#recordlist-search-form');
+    if (!form) return;
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'reset_view';
+    input.value = '1';
+    form.appendChild(input);
+    form.submit();
+  }
+}
+
+new RecordlistResetView();

--- a/Tests/Playwright/helpers/typo3-backend.ts
+++ b/Tests/Playwright/helpers/typo3-backend.ts
@@ -90,6 +90,13 @@ export async function openColumnsModal(page: Page, contentFrame: FrameLocator): 
   await page.locator('.modal').waitFor({ timeout: 5000 });
 }
 
+export async function clickResetView(page: Page, contentFrame: FrameLocator): Promise<void> {
+  await contentFrame.locator('button.dropdown-toggle').filter({ hasText: 'View' }).click();
+  await page.waitForTimeout(300);
+  await contentFrame.locator('[data-doc-button="resetViewButton"]').evaluate((el) => (el as HTMLElement).click());
+  await waitForReload(contentFrame);
+}
+
 export async function toggleColumn(page: Page, contentFrame: FrameLocator, columnName: string): Promise<void> {
   await openColumnsModal(page, contentFrame);
   // Checkbox is in the modal (main frame) — use JS click to avoid styled-element interception

--- a/Tests/Playwright/shared/reset-view.spec.ts
+++ b/Tests/Playwright/shared/reset-view.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin, openModule, toggleColumn, clickResetView, searchFor } from '../helpers/typo3-backend';
+import { resetDatabase, resetUserPreferences } from '../helpers/db-reset';
+import { trackConsoleErrors, ConsoleErrorTracker } from '../helpers/console-errors';
+
+test.describe('Reset view', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeAll(() => { resetDatabase(); });
+  test.afterAll(() => { resetDatabase(); });
+
+  let consoleErrors: ConsoleErrorTracker;
+  test.beforeEach(async ({ page }) => {
+    consoleErrors = trackConsoleErrors(page);
+    resetUserPreferences();
+    await loginAsAdmin(page);
+  });
+  test.afterEach(() => { consoleErrors.assertNoErrors(); });
+
+  test('reset view button is visible in View dropdown', async ({ page }) => {
+    const contentFrame = await openModule(page, 'example_beusers');
+    await contentFrame.locator('button.dropdown-toggle').filter({ hasText: 'View' }).click();
+    await page.waitForTimeout(300);
+    await expect(contentFrame.locator('[data-doc-button="resetViewButton"]')).toBeAttached();
+  });
+
+  test('reset view restores default columns', async ({ page }) => {
+    const contentFrame = await openModule(page, 'example_beusers');
+
+    // Add a non-default column
+    await toggleColumn(page, contentFrame, 'lastlogin');
+    await expect(contentFrame.locator('thead')).toContainText('Last login');
+
+    // Reset view removes it
+    await clickResetView(page, contentFrame);
+    await expect(contentFrame.locator('thead')).not.toContainText('Last login');
+    await expect(contentFrame.locator('thead')).toContainText('Username');
+  });
+
+  test('reset view clears active search', async ({ page }) => {
+    const contentFrame = await openModule(page, 'example_beusers');
+
+    // Apply a search that returns no results — main.recordlist should not be rendered
+    await searchFor(contentFrame, 'nonexistentuser12345');
+    await expect(contentFrame.locator('main.recordlist')).not.toBeVisible();
+
+    // Reset view clears the search and the admin user reappears
+    await clickResetView(page, contentFrame);
+    await expect(contentFrame.locator('main.recordlist')).toBeVisible();
+    await expect(contentFrame.locator('main.recordlist')).toContainText('admin');
+  });
+});

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,6 +13,12 @@ parameters:
 			path: Classes/Controller/AbstractBackendController.php
 
 		-
+			message: '#^Offset ''uid'' on array\{uid\: ''all''\|int, title\: string, ISOcode\: string, flagIcon\: string\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: Classes/Controller/AbstractBackendController.php
+
+		-
 			message: '#^Property Xima\\XimaTypo3Recordlist\\Controller\\AbstractBackendController\:\:\$records \(array\<string, array\<int\|string, mixed\>\>\) does not accept list\<array\<mixed\>\>\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -21,11 +27,5 @@ parameters:
 		-
 			message: '#^Property Xima\\XimaTypo3Recordlist\\Controller\\AbstractBackendController\:\:\$records \(array\<string, array\<int\|string, mixed\>\>\) does not accept list\<array\<string, mixed\>\>\.$#'
 			identifier: assign.propertyType
-			count: 1
-			path: Classes/Controller/AbstractBackendController.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between ''all''\|numeric\-string and int will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
 			count: 1
 			path: Classes/Controller/AbstractBackendController.php


### PR DESCRIPTION
resolves #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Reset view" button in the View dropdown menu that restores default table columns and clears active search filters, allowing users to quickly return to the default view state.

* **Tests**
  * Added comprehensive end-to-end tests for the reset view feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->