### PR TITLE
fix: declare composer type `typo3-cms-extension`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "xima/xima-typo3-recordlist",
 	"description": "This package provides an abstract class for creating TYPO3 backend modules that display a feature-rich and easy-to-customize list view of records. It also includes built-in simplified TYPO3 workspace integration.",
 	"license": "GPL-2.0-or-later",
-	"type": "library",
+	"type": "typo3-cms-extension",
 	"keywords": [
 		"typo3",
 		"typo3-cms-extension"


### PR DESCRIPTION
Was type:library, which TYPO3's runtime installer tolerates via extra.typo3/cms.extension-key, but the testing framework (and any strict extension-discovery) does not recognize it as a TYPO3 extension. Functional tests in consuming extensions could not load it, so its Services.yaml (e.g. RelationResolver) was never registered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to properly classify the extension in package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->