### PR TITLE
feat: display error message in case of missing storage

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -183,8 +183,10 @@ abstract class AbstractBackendController extends ActionController implements Bac
         // Get site
         $this->setSite();
 
-        // check access + redirect
-        $this->accessCheck();
+        // No accessible record storage found
+        if ($this->getAccessiblePids() === []) {
+            return $this->renderNoStorageResponse();
+        }
 
         if (!in_array($this->getCurrentPid(), $this->getAccessiblePids(), true)) {
             return new RedirectResponse($this->getCurrentUrl());
@@ -285,12 +287,22 @@ abstract class AbstractBackendController extends ActionController implements Bac
         return null;
     }
 
-    protected function accessCheck(): void
+    /**
+     * Render the module with a "no record storage" infobox instead of crashing
+     * when no accessible storage pid is configured/available yet.
+     */
+    protected function renderNoStorageResponse(): ResponseInterface
     {
-        $accessiblePids = $this->getAccessiblePids();
-        if (!count($accessiblePids)) {
-            throw new RouteNotFoundException('No accessible child pages found.', 403);
-        }
+        $this->moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $this->setLanguages();
+        $this->assignViewVariables();
+        $this->moduleTemplate->assignMultiple([
+            'noStorage' => true,
+            'records' => [],
+            'recordCount' => 0,
+        ]);
+
+        return $this->moduleTemplate->renderResponse($this->getTemplateName());
     }
 
     /**
@@ -662,6 +674,10 @@ abstract class AbstractBackendController extends ActionController implements Bac
      */
     protected function getFullRecordCount(): int
     {
+        if ($this->getRequestedPids() === []) {
+            return 0;
+        }
+
         $tableName = $this->getTableName();
         $qb = $this->connectionPool->getQueryBuilderForTable($tableName);
         $qb->getRestrictions()->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $this::WORKSPACE_ID));

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -183,6 +183,14 @@
 				<source />
 				<target>Hier sind noch keine Datensätze vorhanden. Sobald der erste Datensatz angelegt wurde, erscheint er in dieser Liste.</target>
 			</trans-unit>
+			<trans-unit id="noStorage.headline">
+				<source />
+				<target>Kein Speicher verfügbar</target>
+			</trans-unit>
+			<trans-unit id="noStorage.text">
+				<source />
+				<target>Es wurde keine zugängliche Seite für dieses Modul gefunden. Dies könnte auf fehlende Berechtigungen oder eine Fehlkonfiguration zurückzuführen sein. Bitte wenden Sie sich an Ihren Administrator.</target>
+			</trans-unit>
 			<trans-unit id="table.button.save" approved="yes">
 				<source />
 				<target>Speichern</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -138,6 +138,12 @@
 			<trans-unit id="emptyState.text">
 				<source>There are no records here yet. Once the first record is created, it will appear in this list.</source>
 			</trans-unit>
+			<trans-unit id="noStorage.headline">
+				<source>No record storage available</source>
+			</trans-unit>
+			<trans-unit id="noStorage.text">
+				<source>No accessible storage was found for this module. This could be due to missing permissions or a misconfiguration. Please contact your administrator.</source>
+			</trans-unit>
 			<trans-unit id="table.button.save">
 				<source>Save</source>
 			</trans-unit>

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -45,9 +45,18 @@
                 <f:if condition="{fullRecordCount} == 0">
                     <f:then>
 
-                        <f:render section="EmptyState" arguments="{_all}" optional="true">
-                            <f:render partial="EmptyState" arguments="{_all}" />
-                        </f:render>
+                        <f:if condition="{noStorage}">
+                            <f:then>
+                                <f:render section="NoStorage" arguments="{_all}" optional="true">
+                                    <f:render partial="NoStorage" arguments="{_all}" />
+                                </f:render>
+                            </f:then>
+                            <f:else>
+                                <f:render section="EmptyState" arguments="{_all}" optional="true">
+                                    <f:render partial="EmptyState" arguments="{_all}" />
+                                </f:render>
+                            </f:else>
+                        </f:if>
 
                     </f:then>
                     <f:else>

--- a/Resources/Private/Partials/NoStorage.html
+++ b/Resources/Private/Partials/NoStorage.html
@@ -1,0 +1,18 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true">
+
+<f:comment>
+    Shown when no accessible record storage exists yet (e.g. the storage folder
+    has not been created). Override this partial — or the "NoStorage" template
+    section — to adjust the message or switch the infobox state from error (2)
+    to an informational hint (-1) once the editor can resolve it themselves.
+</f:comment>
+
+<f:be.infobox
+    title="{f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:noStorage.headline')}"
+    state="2">
+    {f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:noStorage.text')}
+</f:be.infobox>
+</html>


### PR DESCRIPTION
Display error message when no accessible pages are found. In some installations the editor can resolve the issue, e.g. by creating a special record storage. In this case, the error message partial can be overridden in favior of an info message + tutorial.

resolves #98 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no accessible record storage pages are configured. Users now see a helpful message with guidance instead of an error, available in English and German.

* **New Features**
  * Added a dedicated information box interface to communicate storage configuration issues to administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->