### PR TITLE
fix: fallback to record pid for preview link generation

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -1985,8 +1985,8 @@ abstract class AbstractBackendController extends ActionController implements Bac
     {
         // check if preview is possible
         $previewSettings = BackendUtility::getPagesTSconfig($this->getAccessiblePids()[0] ?? 0)['TCEMAIN.']['preview.'][$this->getTableName() . '.'] ?? [];
-        $previewPageId = $previewSettings['previewPageId'] ?? 0;
-        if ($this->getTableName() !== 'pages' && $this->getTableName() !== 'tt_content' && !MathUtility::canBeInterpretedAsInteger($previewPageId)) {
+        $configuredPreviewPageId = $previewSettings['previewPageId'] ?? 0;
+        if ($this->getTableName() !== 'pages' && $this->getTableName() !== 'tt_content' && !MathUtility::canBeInterpretedAsInteger($configuredPreviewPageId)) {
             return;
         }
 
@@ -2001,6 +2001,9 @@ abstract class AbstractBackendController extends ActionController implements Bac
             if ($isWorkspaceAware) {
                 $this->getBackendAuthentication()->workspace = $this::WORKSPACE_ID;
             }
+
+            // A configured previewPageId (TSconfig) wins; otherwise fall back to the record's own pid
+            $previewPageId = $configuredPreviewPageId ?: ($record['pid'] ?? 0);
 
             if ($this->getTableName() === 'pages') {
                 $previewPageId = $record['uid'];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -23,21 +23,3 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: Classes/Controller/AbstractBackendController.php
-
-		-
-			message: '#^Offset ''TCA'' on array\<mixed, mixed\> in isset\(\) does not exist\.$#'
-			identifier: isset.offset
-			count: 1
-			path: Classes/Utility/RelationResolver.php
-
-		-
-			message: '#^Offset mixed on null in isset\(\) does not exist\.$#'
-			identifier: isset.offset
-			count: 3
-			path: Classes/Utility/RelationResolver.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 4
-			path: Classes/Utility/RelationResolver.php


### PR DESCRIPTION
resolves #103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview link handling so records use the correct preview page when a site-wide preview page is configured.
  * Added validation to prevent invalid preview page values from being used, while keeping existing behavior for page and content records.
  * Ensured preview URLs fall back to the record’s parent page when no configured preview page is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->