### PR TITLE
fix: use current pid in category filter form element

### DIFF
--- a/Classes/Middleware/CategoryTreeManipulation.php
+++ b/Classes/Middleware/CategoryTreeManipulation.php
@@ -30,7 +30,7 @@ class CategoryTreeManipulation implements MiddlewareInterface
         $uid = $params['uid'] ?? '';
 
         // make sure it is the right request
-        if (empty($overrideValues) || $command !== 'new' || $fieldName !== 'categories' || $uid !== '1') {
+        if (empty($overrideValues) || $command !== 'new' || $fieldName !== 'categories') {
             return $handler->handle($request);
         }
 

--- a/Classes/Middleware/CategoryTreeManipulation.php
+++ b/Classes/Middleware/CategoryTreeManipulation.php
@@ -26,11 +26,9 @@ class CategoryTreeManipulation implements MiddlewareInterface
         $params = $request->getQueryParams();
         $overrideValues = json_decode($params['overrideValues'] ?? '[]', true, 512, JSON_THROW_ON_ERROR);
         $command = $params['command'] ?? '';
-        $fieldName = $params['fieldName'] ?? '';
-        $uid = $params['uid'] ?? '';
 
         // make sure it is the right request
-        if (empty($overrideValues) || $command !== 'new' || $fieldName !== 'categories') {
+        if (empty($overrideValues) || $command !== 'new') {
             return $handler->handle($request);
         }
 

--- a/Resources/Private/Partials/Filter/Category.html
+++ b/Resources/Private/Partials/Filter/Category.html
@@ -21,7 +21,7 @@
                 class="treeRecord"
                 name="{fieldName}"
                 value="{fieldValue}"
-                data-uid="1"
+                data-uid="{currentPid}"
                 data-command="new"
                 data-fieldname="{fieldNameOrig}"
                 data-tablename="{tableName}"


### PR DESCRIPTION
resolves #105 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Category filters now work correctly across different page contexts instead of being limited to a single page identifier.
  * Hidden category fields now use the current page identifier dynamically, improving filtering accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->