### PR TITLE
fix: hide view, download and filter buttons when there are no records

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -116,6 +116,8 @@ abstract class AbstractBackendController extends ActionController implements Bac
 
     protected array $viewDropdownButtons = [];
 
+    protected ?int $fullRecordCount = null;
+
     protected ConnectionPool $connectionPool;
 
     protected IconFactory $iconFactory;
@@ -674,8 +676,12 @@ abstract class AbstractBackendController extends ActionController implements Bac
      */
     protected function getFullRecordCount(): int
     {
+        if ($this->fullRecordCount !== null) {
+            return $this->fullRecordCount;
+        }
+
         if ($this->getRequestedPids() === []) {
-            return 0;
+            return $this->fullRecordCount = 0;
         }
 
         $tableName = $this->getTableName();
@@ -691,7 +697,7 @@ abstract class AbstractBackendController extends ActionController implements Bac
             ->executeQuery()
             ->fetchNumeric();
 
-        return $count ? $count[0] : 0;
+        return $this->fullRecordCount = ($count ? $count[0] : 0);
     }
 
     protected function getRequestedPids(): array
@@ -2182,6 +2188,11 @@ abstract class AbstractBackendController extends ActionController implements Bac
 
     protected function addDownloadButtonToModuleTemplate(): void
     {
+        // With no records at all the export would be empty; skip the button.
+        if ($this->getFullRecordCount() === 0) {
+            return;
+        }
+
         if (!$this->isActionAllowedInCurrentTemplate('download')) {
             return;
         }
@@ -2238,6 +2249,11 @@ abstract class AbstractBackendController extends ActionController implements Bac
 
     protected function addToggleFiltersButtonToNewModuleTemplate(): void
     {
+        // With no records at all there is nothing to filter; skip the button.
+        if ($this->getFullRecordCount() === 0) {
+            return;
+        }
+
         if (!$this->isActionAllowedInCurrentTemplate('toggleFilters')) {
             return;
         }
@@ -2498,6 +2514,11 @@ abstract class AbstractBackendController extends ActionController implements Bac
 
     protected function addViewDropdownButtonToModuleTemplate(): void
     {
+        // With no records at all there is no table to configure; skip the button.
+        if ($this->getFullRecordCount() === 0) {
+            return;
+        }
+
         if (empty($this->viewDropdownButtons)) {
             return;
         }


### PR DESCRIPTION
Resolves #107.

### Problem

When a storage contains **no records at all**, the list module shows only the empty-state infobox — but the doc-header still rendered the **view**, **download** and **filter** buttons. With zero records these are dead controls (nothing to filter, no columns to configure, an empty export).

### Change

In `AbstractBackendController::configureModuleTemplateDocHeader()`, the view dropdown, download and filter-toggle buttons are now only registered when `getFullRecordCount() > 0`.

- The **New** button and the language/page/table selectors stay — they remain useful with an empty list.
- `getFullRecordCount()` is memoized (`?int $fullRecordCount`) so the guard reuses the count already fetched in `assignViewVariables()` instead of firing a second query.

### Why `fullRecordCount`, not `recordCount`

The guard checks the *total* record count, not the filtered result count. When records exist but a search/filter returns zero matches, the buttons still show so the user can reset the filter — that path is unchanged.

### Verification

- `ddev php -l` passes.
- No concrete controller overrides `configureModuleTemplateDocHeader()` or `getFullRecordCount()`, so the guard applies to all list modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty result sets by caching record counts.
  - Prevented view, download, and filter controls from appearing when no records are available.
  - Reduced unnecessary repeated record-count queries for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->