### PR TITLE
Fix category filter to not check values configured via TSconfig TCAdefaults

### DIFF
--- a/Classes/Middleware/CategoryTreeManipulation.php
+++ b/Classes/Middleware/CategoryTreeManipulation.php
@@ -25,6 +25,7 @@ class CategoryTreeManipulation implements MiddlewareInterface
 
         $params = $request->getQueryParams();
         $overrideValues = json_decode($params['overrideValues'] ?? '[]', true, 512, JSON_THROW_ON_ERROR);
+        $overrideValues = array_map(static fn ($value): int => (int)$value, $overrideValues);
         $recordTypeValue = $params['recordTypeValue'] ?? '';
         $command = $params['command'] ?? '';
 

--- a/Classes/Middleware/CategoryTreeManipulation.php
+++ b/Classes/Middleware/CategoryTreeManipulation.php
@@ -39,12 +39,7 @@ class CategoryTreeManipulation implements MiddlewareInterface
             $response = $handler->handle($request);
             $treeData = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
             foreach ($treeData as &$treeItem) {
-                if (in_array((int)$treeItem['identifier'], $overrideValues, true)) {
-                    $treeItem['checked'] = true;
-                } else {
-                    // uncheck items that are not within $overrideValues (possibly set via TSconfig TCAdefaults for new records)
-                    $treeItem['checked'] = false;
-                }
+                $treeItem['checked'] = in_array((int)$treeItem['identifier'], $overrideValues, true);
             }
             return new JsonResponse($treeData);
         } catch (\Exception) {

--- a/Classes/Middleware/CategoryTreeManipulation.php
+++ b/Classes/Middleware/CategoryTreeManipulation.php
@@ -39,12 +39,12 @@ class CategoryTreeManipulation implements MiddlewareInterface
             $response = $handler->handle($request);
             $treeData = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
             foreach ($treeData as &$treeItem) {
-                if (!in_array((int)$treeItem['identifier'], $overrideValues, true)) {
+                if (in_array((int)$treeItem['identifier'], $overrideValues, true)) {
+                    $treeItem['checked'] = true;
+                } else {
                     // uncheck items that are not within $overrideValues (possibly set via TSconfig TCAdefaults for new records)
                     $treeItem['checked'] = false;
-                    continue;
                 }
-                $treeItem['checked'] = true;
             }
             return new JsonResponse($treeData);
         } catch (\Exception) {

--- a/Classes/Middleware/CategoryTreeManipulation.php
+++ b/Classes/Middleware/CategoryTreeManipulation.php
@@ -30,7 +30,7 @@ class CategoryTreeManipulation implements MiddlewareInterface
         $uid = $params['uid'] ?? '';
 
         // make sure it is the right request
-        if (empty($overrideValues) || $command !== 'new' || $fieldName !== 'categories' || $uid !== '1') {
+        if (empty($overrideValues) || $command !== 'new' || $fieldName !== 'categories') {
             return $handler->handle($request);
         }
 

--- a/Classes/Middleware/CategoryTreeManipulation.php
+++ b/Classes/Middleware/CategoryTreeManipulation.php
@@ -25,10 +25,11 @@ class CategoryTreeManipulation implements MiddlewareInterface
 
         $params = $request->getQueryParams();
         $overrideValues = json_decode($params['overrideValues'] ?? '[]', true, 512, JSON_THROW_ON_ERROR);
+        $recordTypeValue = $params['recordTypeValue'] ?? '';
         $command = $params['command'] ?? '';
 
         // make sure it is the right request
-        if (empty($overrideValues) || $command !== 'new') {
+        if ($recordTypeValue !== 'tx-ximatypo3recordlist-filter' || $command !== 'new') {
             return $handler->handle($request);
         }
 
@@ -38,6 +39,8 @@ class CategoryTreeManipulation implements MiddlewareInterface
             $treeData = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
             foreach ($treeData as &$treeItem) {
                 if (!in_array((int)$treeItem['identifier'], $overrideValues, true)) {
+                    // uncheck items that are not within $overrideValues (possibly set via TSconfig TCAdefaults for new records)
+                    $treeItem['checked'] = false;
                     continue;
                 }
                 $treeItem['checked'] = true;

--- a/Classes/Middleware/CategoryTreeManipulation.php
+++ b/Classes/Middleware/CategoryTreeManipulation.php
@@ -26,11 +26,9 @@ class CategoryTreeManipulation implements MiddlewareInterface
         $params = $request->getQueryParams();
         $overrideValues = json_decode($params['overrideValues'] ?? '[]', true, 512, JSON_THROW_ON_ERROR);
         $command = $params['command'] ?? '';
-        $fieldName = $params['fieldName'] ?? '';
-        $uid = $params['uid'] ?? '';
 
         // make sure it is the right request
-        if (empty($overrideValues) || $command !== 'new' || $fieldName !== 'categories') {
+        if (empty($overrideValues) || $command !== 'new') {
             return $handler->handle($request);
         }
 

--- a/Resources/Private/Partials/Filter/Category.html
+++ b/Resources/Private/Partials/Filter/Category.html
@@ -21,7 +21,7 @@
                 class="treeRecord"
                 name="{fieldName}"
                 value="{fieldValue}"
-                data-uid="1"
+                data-uid="{currentPid}"
                 data-command="new"
                 data-fieldname="{fieldNameOrig}"
                 data-tablename="{tableName}"

--- a/Resources/Private/Partials/Filter/Category.html
+++ b/Resources/Private/Partials/Filter/Category.html
@@ -27,7 +27,7 @@
                 data-tablename="{tableName}"
                 data-read-only=""
                 data-tree-show-toolbar="0"
-                data-recordtypevalue="1"
+                data-recordtypevalue="tx-ximatypo3recordlist-filter"
                 data-relatedfieldname=""
                 data-flexformsheetname=""
                 data-flexformfieldname=""


### PR DESCRIPTION
If there are default values configured (via TSconfig), these values get always checked in the filter tree.

By using a custom distinct value for the `data-recordtypevalue` attribute we can identify the AJAX calls in our middleware and treat the tree items accordingly: Uncheck every item that is not within the override values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category selection behavior when creating new records through Ajax.
  * Category tree selections are now correctly unchecked when they are not included in the applied filter values.
  * Category filters now use the current page context and the correct record type, improving selection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->