### PR TITLE
fix: keep filter panel visible after search form reset

### DIFF
--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -514,11 +514,11 @@ abstract class AbstractBackendController extends ActionController implements Bac
             if ($isReset) {
                 $body = [];
                 $this->request = $this->request->withParsedBody([]);
-                unset($moduleData['settings']['language'], $moduleData['settings'][$tableName . '.isFilterButtonActive'], $moduleData['settings'][$tableName . '.onlyOfflineRecords'], $moduleData['settings'][$tableName . '.onlyReadyToPublish'], $moduleData['settings'][$tableName . '.itemsPerPage']);
+                unset($moduleData['settings']['language'], $moduleData['settings'][$tableName . '.onlyOfflineRecords'], $moduleData['settings'][$tableName . '.onlyReadyToPublish'], $moduleData['settings'][$tableName . '.itemsPerPage']);
             }
-
+            // additionally clear columns and visibility settings in reset view button
             if ($isResetView) {
-                unset($moduleData['settings'][$tableName . '.activeColumns']);
+                unset($moduleData['settings'][$tableName . '.activeColumns'], $moduleData['settings'][$tableName . '.isFilterButtonActive']);
             }
 
             $moduleData[$tableName . '.search'] = $body;

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -83,7 +83,8 @@
                                                 <f:form.submit
                                                     class="btn btn-default"
                                                     name="reset"
-                                                    value="{f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.reset')}" />
+                                                    value="{f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.reset')}"
+                                                    additionalAttributes="{formaction: '#filterInputs'}" />
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
The search form reset button collapses the search filter panel.
Which is not desired by editors working heavily with the search form,
they just want to the reset the current filter combinations
and keep going. The current change removes the vivsibilty state from
the reset action in order to keep the search form visible.

Also stay at the search form and dont scroll to the result list instead
when the reset button is hit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting module data now preserves the table’s filter button visibility setting.
  * Resetting filters now correctly targets the filter input area for improved behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->