### PR TITLE
feat: allow disabling action group dropdowns per table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- **Optional Action Grouping**: `enableActionGroups` in the table configuration switches the translation/workspace action dropdowns off per table, rendering every row action as a plain button again.
 - **Multiple Record Sources**: New `getRecordSources()` override exposes records from several pages/folders at once via `RecordSource` objects, each with an optional recursive `includeSubpages` flag and `depth`. Replaces the implicit "single pid + direct children" entry point.
 - **Multi-Site Directories**: Accessible pages spanning more than one site get site-prefixed labels (e.g. `Site A › News`) in the directory dropdown and the new-record modal, disambiguating identically named folders across mandants.
 

--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -1695,6 +1695,7 @@ abstract class AbstractBackendController extends ActionController implements Bac
             'columns' => $columns,
             'showCheckboxColumn' => true,
             'showIconColumn' => true,
+            'enableActionGroups' => true,
             'groupActions' => $groupActions,
             'actions' => [
                 'Changelog',

--- a/README.md
+++ b/README.md
@@ -494,7 +494,9 @@ column narrow. The grouping is markup-driven — `recordlist-action-groups.js` d
 groups from the DOM and needs no change to support a new one.
 
 To switch the dropdowns off for a table and render every action as a plain button in the
-bar:
+bar. The workflow actions (`actions`) then form their own button group beside the
+per-record ones (`groupActions`), and the icon-only workflow buttons carry a visible label
+instead of a tooltip:
 
 ```php
 class NewsController extends AbstractBackendController

--- a/README.md
+++ b/README.md
@@ -493,6 +493,19 @@ Translation and workspace row actions are collapsed into dropdowns to keep the a
 column narrow. The grouping is markup-driven — `recordlist-action-groups.js` discovers the
 groups from the DOM and needs no change to support a new one.
 
+To switch the dropdowns off for a table and render every action as a plain button in the
+bar:
+
+```php
+class NewsController extends AbstractBackendController
+{
+    protected function modifyTableConfiguration(): void
+    {
+        $this->tableConfiguration['tx_news_domain_model_news']['enableActionGroups'] = false;
+    }
+}
+```
+
 To add a group (e.g. `publishing`):
 
 1. **Add a dropdown shell** in your `ActionGroupDropdowns.html` partial, marked with

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -202,12 +202,25 @@
                                                                     <f:render partial="Actions/{actionName}" arguments="{_all}" />
                                                                 </f:for>
                                                             </f:if>
-                                                            <f:if condition="{tableConfiguration.actions}">
+                                                            <f:comment>
+                                                                Grouped: the workflow actions render into the same bar and the module
+                                                                relocates the tagged ones into their dropdown. Ungrouped: they render as
+                                                                their own button group beside it (see below), so the workflow cluster
+                                                                stays visually separate from the per-record actions.
+                                                            </f:comment>
+                                                            <f:if condition="{tableConfiguration.actions} && {tableConfiguration.enableActionGroups}">
                                                                 <f:for each="{tableConfiguration.actions}" as="actionName">
                                                                     <f:render partial="Actions/{actionName}" arguments="{_all}" />
                                                                 </f:for>
                                                             </f:if>
                                                         </div>
+                                                        <f:if condition="{tableConfiguration.actions} && !{tableConfiguration.enableActionGroups}">
+                                                            <div class="btn-group recordlist-actions-ungrouped recordlist-actions-workflow">
+                                                                <f:for each="{tableConfiguration.actions}" as="actionName">
+                                                                    <f:render partial="Actions/{actionName}" arguments="{_all}" />
+                                                                </f:for>
+                                                            </div>
+                                                        </f:if>
                                                         <f:if condition="{tableConfiguration.enableActionGroups}">
                                                             <f:render partial="ActionGroupDropdowns" arguments="{_all}" />
                                                         </f:if>

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -196,7 +196,7 @@
                                             <f:if condition="{tableConfiguration.groupActions} || {tableConfiguration.actions}">
                                                 <td>
                                                     <div class="recordlist-actions">
-                                                        <div class="btn-group" data-recordlist-actions>
+                                                        <div class="btn-group{f:if(condition: tableConfiguration.enableActionGroups, else: ' recordlist-actions-ungrouped')}" data-recordlist-actions>
                                                             <f:if condition="{tableConfiguration.groupActions}">
                                                                 <f:for each="{tableConfiguration.groupActions}" as="actionName">
                                                                     <f:render partial="Actions/{actionName}" arguments="{_all}" />
@@ -208,7 +208,9 @@
                                                                 </f:for>
                                                             </f:if>
                                                         </div>
-                                                        <f:render partial="ActionGroupDropdowns" arguments="{_all}" />
+                                                        <f:if condition="{tableConfiguration.enableActionGroups}">
+                                                            <f:render partial="ActionGroupDropdowns" arguments="{_all}" />
+                                                        </f:if>
                                                     </div>
                                                 </td>
                                             </f:if>

--- a/Resources/Private/Partials/Actions/Changelog.html
+++ b/Resources/Private/Partials/Actions/Changelog.html
@@ -5,9 +5,13 @@
         href="#"
         class="btn btn-default"
         data-action-group="workspace"
-        title="{f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.changelog')}"
-        data-bs-toggle="tooltip"
+        aria-label="{f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.changelog')}"
+        title="{f:if(condition: tableConfiguration.enableActionGroups, then: '{f:translate(key:\'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.changelog\')}')}"
+        data-bs-toggle="{f:if(condition: tableConfiguration.enableActionGroups, then: 'tooltip')}"
         data-action="changes">
         <core:icon identifier="actions-info" size="small" />
+        <f:if condition="!{tableConfiguration.enableActionGroups}">
+            <span class="recordlist-action-label">{f:translate(key:'LLL:EXT:xima_typo3_recordlist/Resources/Private/Language/locallang.xlf:table.button.changelog')}</span>
+        </f:if>
     </a>
 </f:if>

--- a/Resources/Private/Partials/Actions/Revert.html
+++ b/Resources/Private/Partials/Actions/Revert.html
@@ -10,10 +10,14 @@
         href="#"
         class="btn btn-danger"
         data-action-group="workspace"
-        title="{f:translate(key:label)}"
-        data-bs-toggle="tooltip"
+        aria-label="{f:translate(key:label)}"
+        title="{f:if(condition: tableConfiguration.enableActionGroups, then: '{f:translate(key:label)}')}"
+        data-bs-toggle="{f:if(condition: tableConfiguration.enableActionGroups, then: 'tooltip')}"
         data-workspace-action="remove"
         data-typo3-version="{typo3version}">
         <core:icon identifier="actions-undo" size="small" />
+        <f:if condition="!{tableConfiguration.enableActionGroups}">
+            <span class="recordlist-action-label">{f:translate(key:label)}</span>
+        </f:if>
     </a>
 </f:if>

--- a/Resources/Public/Css/recordlist.css
+++ b/Resources/Public/Css/recordlist.css
@@ -166,10 +166,16 @@ main.recordlist ul.pagination input.form-control {
 }
 
 /** A single group may still be wider than the column on a narrow window; let its buttons
-    wrap too rather than overflow the cell. */
+    wrap too rather than overflow the cell. Bootstrap lets a group button grow to fill the
+    line (`flex: 1 1 auto`), which a wrapped row would stretch across the whole cell — keep
+    every button at its content width instead. */
 .recordlist-actions .btn-group {
     flex-wrap: wrap;
     row-gap: 0.25rem;
+}
+
+.recordlist-actions .btn-group > .btn {
+    flex: 0 0 auto;
 }
 
 /** Inline labels next to an icon in the bar (icon-only actions carry their name in a

--- a/Resources/Public/Css/recordlist.css
+++ b/Resources/Public/Css/recordlist.css
@@ -155,6 +155,18 @@ main.recordlist ul.pagination input.form-control {
     display: none;
 }
 
+/** Without the dropdowns the workflow actions form their own button group, set apart from
+    the per-record actions rather than joined into them. */
+.recordlist-actions-workflow {
+    margin-inline-start: 0.5rem;
+}
+
+/** Inline labels next to an icon in the bar (icon-only actions carry their name in a
+    tooltip only, which reads as a gap beside the labelled workflow buttons). */
+.recordlist-actions-ungrouped .btn > .recordlist-action-label {
+    margin-inline-start: 0.375rem;
+}
+
 /** Standalone dropdowns sit beside the action button bar, not joined into it. */
 .recordlist-action-group {
     margin-inline-start: 0.5rem;

--- a/Resources/Public/Css/recordlist.css
+++ b/Resources/Public/Css/recordlist.css
@@ -140,8 +140,9 @@ main.recordlist ul.pagination input.form-control {
 /** Semantic action dropdowns collapsing translation / workspace row actions. */
 /** Avoid a flash of ungrouped actions on load: hide the buttons destined for a dropdown
     until the module has processed the bar and relocated them (the move happens in the same
-    JS task, so they are never painted in the bar). Requires the JS module to run. */
-[data-recordlist-actions]:not([data-recordlist-actions-processed]) [data-action-group] {
+    JS task, so they are never painted in the bar). Requires the JS module to run — a bar
+    marked `.recordlist-actions-ungrouped` keeps every action in place and is exempt. */
+[data-recordlist-actions]:not(.recordlist-actions-ungrouped):not([data-recordlist-actions-processed]) [data-action-group] {
     display: none;
 }
 

--- a/Resources/Public/Css/recordlist.css
+++ b/Resources/Public/Css/recordlist.css
@@ -155,21 +155,27 @@ main.recordlist ul.pagination input.form-control {
     display: none;
 }
 
-/** Without the dropdowns the workflow actions form their own button group, set apart from
-    the per-record actions rather than joined into them. */
-.recordlist-actions-workflow {
-    margin-inline-start: 0.5rem;
+/** The action cell lays its button groups out as flex items so a group that does not fit
+    the column wraps onto its own line with vertical spacing, instead of flowing inline and
+    carrying a left indent into the new line. */
+.recordlist-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+/** A single group may still be wider than the column on a narrow window; let its buttons
+    wrap too rather than overflow the cell. */
+.recordlist-actions .btn-group {
+    flex-wrap: wrap;
+    row-gap: 0.25rem;
 }
 
 /** Inline labels next to an icon in the bar (icon-only actions carry their name in a
     tooltip only, which reads as a gap beside the labelled workflow buttons). */
 .recordlist-actions-ungrouped .btn > .recordlist-action-label {
     margin-inline-start: 0.375rem;
-}
-
-/** Standalone dropdowns sit beside the action button bar, not joined into it. */
-.recordlist-action-group {
-    margin-inline-start: 0.5rem;
 }
 
 /** Icon-only toggles — suppress the default Bootstrap caret. */

--- a/Resources/Public/JavaScript/recordlist-action-groups.js
+++ b/Resources/Public/JavaScript/recordlist-action-groups.js
@@ -20,9 +20,13 @@ export default class RecordlistActionGroups {
     });
   }
 
+  // A bar marked `.recordlist-actions-ungrouped` opted out of grouping and keeps every
+  // action in the bar.
   groupAll() {
     document
-      .querySelectorAll(`[data-recordlist-actions]:not([${RecordlistActionGroups.PROCESSED_ATTR}])`)
+      .querySelectorAll(
+        `[data-recordlist-actions]:not(.recordlist-actions-ungrouped):not([${RecordlistActionGroups.PROCESSED_ATTR}])`
+      )
       .forEach(bar => this.groupBar(bar));
   }
 

--- a/Tests/Playwright/shared/action-groups.spec.ts
+++ b/Tests/Playwright/shared/action-groups.spec.ts
@@ -174,4 +174,35 @@ test.describe('Action group dropdowns', () => {
 
     await expect(contentFrame.locator('#unprocessed-bar [data-action-group]')).toBeHidden();
   });
+
+  test('an ungrouped bar keeps its actions visible and in place', async ({ page }) => {
+    const contentFrame = await openModule(page, 'example_beusers');
+    // Mirrors a table with `enableActionGroups = false`: the bar carries the opt-out class
+    // and no dropdown shells are rendered.
+    await contentFrame.locator('main.recordlist').evaluate(main => {
+      const cell = document.createElement('div');
+      cell.id = 'ungrouped';
+      cell.className = 'recordlist-actions';
+      const bar = document.createElement('div');
+      bar.className = 'btn-group recordlist-actions-ungrouped';
+      bar.setAttribute('data-recordlist-actions', '');
+      ['workspace', 'translation'].forEach(group => {
+        const action = document.createElement('a');
+        action.className = 'btn btn-default';
+        action.href = '#';
+        action.setAttribute('data-action-group', group);
+        action.textContent = group;
+        bar.appendChild(action);
+      });
+      cell.appendChild(bar);
+      main.appendChild(cell);
+    });
+
+    await expect(contentFrame.locator('#ungrouped [data-action-group]')).toHaveCount(2);
+    await expect(contentFrame.locator('#ungrouped [data-action-group="workspace"]')).toBeVisible();
+    await expect(contentFrame.locator('#ungrouped [data-action-group="translation"]')).toBeVisible();
+    // The module leaves the bar alone — no labels added, nothing relocated.
+    await expect(contentFrame.locator('#ungrouped .recordlist-action-label')).toHaveCount(0);
+    await expect(contentFrame.locator('#ungrouped [data-recordlist-actions-processed]')).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
Add the table configuration flag `enableActionGroups` (default `true`). When disabled, the dropdown shells are not rendered, the action bar is marked `recordlist-actions-ungrouped`, and both the flash-hide CSS rule and the grouping module skip it, so every row action stays a plain button in the bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-table configuration to display workflow and record actions as separate buttons instead of grouped dropdowns.
  * Ungrouped actions now retain visible labels and support accessible descriptions.
  * Action buttons wrap cleanly on smaller screens for improved usability.

* **Documentation**
  * Added guidance for configuring action grouping per table.

* **Tests**
  * Added coverage verifying that ungrouped actions remain visible and in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->